### PR TITLE
Visualization performance

### DIFF
--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/AbstractDataVisualization.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/AbstractDataVisualization.java
@@ -47,6 +47,7 @@ public abstract class AbstractDataVisualization implements DataVisualization {
     protected void addEntity(OvationEntity e) {
         entities.add(e);
     }
+    
 
 
     @Override

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/ChartVisualizationFactory.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/ChartVisualizationFactory.java
@@ -41,17 +41,8 @@ public class ChartVisualizationFactory implements VisualizationFactory {
     }
 
     @Override
-    public int getPreferenceForDataContainer(Resource r) {
-        if (NumericDataElements.isNumeric(r)) {
-            try {
-                if (NumericDataElements.getNumericData(r).get().getData().size() == 1) {
-                    //TODO maybe there's a better way to show single value data?
-                }
-            } catch (InterruptedException ex) {
-                return -1;
-            } catch (ExecutionException ex) {
-                return -1;
-            }
+    public int getPreferenceForDataContentType(String contentType) {
+        if (contentType.equals(NumericDataElements.NUMERIC_MEASUREMENT_CONTENT_TYPE)) {
             return 100;
         }
         return -1;

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/DefaultDataPanel.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/DefaultDataPanel.java
@@ -16,18 +16,19 @@ import us.physion.ovation.domain.Resource;
  */
 public class DefaultDataPanel extends JPanel{
 
-    Resource d;
+    Resource resource;
     JLabel elementName;
     JLabel messageLabel;
 
     public DefaultDataPanel(Resource data) {
-        d = data;
+        resource = data;
         this.setLayout(new GridBagLayout());
         this.setBackground(Color.white);
         GridBagConstraints c = new GridBagConstraints();
-        elementName = new JLabel(data.getName());
-        messageLabel = new JLabel("Cannot display data of type '" + data.getDataContentType() + "'");
-        JButton openButton = new JButton(new OpenInNativeAppAction(d));
+        elementName = new JLabel(data.getLabel());
+        
+        messageLabel = new JLabel("Unknown data type '" + data.getDataContentType() + "'");
+        JButton openButton = new JButton(new OpenInNativeAppAction(resource));
 
         c.insets = new Insets(10, 10, 10, 10);
         c.anchor = GridBagConstraints.NORTH;
@@ -39,5 +40,13 @@ public class DefaultDataPanel extends JPanel{
         c.gridy = 2;
         c.weighty = 1.0;
         add(openButton, c);
+    }
+
+    public Resource getResource() {
+        return resource;
+    }
+
+    public void setResource(Resource resource) {
+        this.resource = resource;
     }
 }

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/DefaultImageVisualizationFactory.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/DefaultImageVisualizationFactory.java
@@ -18,8 +18,8 @@ public class DefaultImageVisualizationFactory implements VisualizationFactory{
 
 
     @Override
-    public int getPreferenceForDataContainer(Resource r) {
-        String lowercaseUTI = r.getDataContentType().toLowerCase();
+    public int getPreferenceForDataContentType(String contentType) {
+        String lowercaseUTI = contentType.toLowerCase();
         for (String name : ImageIO.getReaderFormatNames()) {
             if (lowercaseUTI.contains(name.toLowerCase())) {
                 return 100;

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/DefaultVisualizationFactory.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/DefaultVisualizationFactory.java
@@ -5,32 +5,42 @@ import javax.swing.JComponent;
 import us.physion.ovation.domain.OvationEntity;
 import us.physion.ovation.domain.Resource;
 
-/**
- *
- * @author huecotanks
- */
-public class DefaultVisualizationFactory implements VisualizationFactory
-{
+public class DefaultVisualizationFactory implements VisualizationFactory {
+
+//    static LoadingCache<Resource, DataVisualization> cache = CacheBuilder.newBuilder()
+//            .maximumSize(100)
+//            .build(new CacheLoader<Resource, DataVisualization>() {
+//                @Override
+//                public DataVisualization load(Resource key) {
+//                    return new DefaultVisualization(key);
+//                }
+//            });
+
     @Override
     public DataVisualization createVisualization(Resource r) {
+        
         return new DefaultVisualization(r);
+
     }
 
     @Override
-    public int getPreferenceForDataContainer(Resource r) {
+    public int getPreferenceForDataContentType(String contentType) {
         return 2;
     }
 
-    class DefaultVisualization extends AbstractDataVisualization    {
+    static class DefaultVisualization extends AbstractDataVisualization {
+
         final Resource data;
-        DefaultVisualization(Resource d)
-        {
+        private final JComponent panel;
+
+        DefaultVisualization(Resource d) {
             data = d;
+            panel = new DefaultDataPanel(data);
         }
 
         @Override
         public JComponent generatePanel() {
-            return new DefaultDataPanel(data);
+            return panel;
         }
 
         @Override

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/DicomVisualizationFactory.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/DicomVisualizationFactory.java
@@ -8,8 +8,8 @@ import us.physion.ovation.domain.Resource;
 public class DicomVisualizationFactory implements VisualizationFactory{
 
     @Override
-    public int getPreferenceForDataContainer(Resource r) {
-        if (r.getDataContentType().equals("application/dicom"))
+    public int getPreferenceForDataContentType(String contentType) {
+        if (contentType.equals("application/dicom"))
         {
             return 100;
         }

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/ImageJVisualizationFactory.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/ImageJVisualizationFactory.java
@@ -23,8 +23,8 @@ public class ImageJVisualizationFactory implements VisualizationFactory {
     }
 
     @Override
-    public int getPreferenceForDataContainer(Resource r) {
-        if (r.getDataContentType().toLowerCase().contains("tif")) {
+    public int getPreferenceForDataContentType(String contentType) {
+        if (contentType.toLowerCase().contains("tif")) {
             return 110;
         }
         return -1;

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/PlainTextVisualizationFactory.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/PlainTextVisualizationFactory.java
@@ -185,8 +185,8 @@ public class PlainTextVisualizationFactory implements VisualizationFactory {
     }
 
     @Override
-    public int getPreferenceForDataContainer(Resource r) {
-        if (PLAIN_TEXT_MIMETYPE.equals(r.getDataContentType())) {
+    public int getPreferenceForDataContentType(String contentType) {
+        if (PLAIN_TEXT_MIMETYPE.equals(contentType)) {
             return 100;
         }
         return -1;

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/ResourceInfoPanel.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/ResourceInfoPanel.java
@@ -16,8 +16,6 @@
  */
 package us.physion.ovation.ui.editor;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.base.Splitter;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -246,22 +244,13 @@ public class ResourceInfoPanel extends javax.swing.JPanel {
     }
 
     <T extends OvationEntity> Iterable<T> getEntities(final Class<T> cls) {
-        return Iterables.transform(Iterables.filter(getElements(), new Predicate<OvationEntity>() {
-            @Override
-            public boolean apply(OvationEntity t) {
-                if (t == null) {
-                    return false;
-                }
-
-                return cls.isAssignableFrom(t.getClass());
+        return Iterables.transform(Iterables.filter(getElements(), (OvationEntity t) -> {
+            if (t == null) {
+                return false;
             }
-        }), new Function<OvationEntity, T>() {
-
-            @Override
-            public T apply(OvationEntity f) {
-                return (T) f;
-            }
-        });
+            
+            return cls.isAssignableFrom(t.getClass());
+        }), (OvationEntity f) -> (T) f);
     }
 
     final Set<Measurement> getMeasurements() {

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/ResourceVisualizationChrome.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/ResourceVisualizationChrome.java
@@ -14,14 +14,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package us.physion.ovation.ui.editor;
 
 import java.awt.BorderLayout;
 import java.awt.Rectangle;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import javax.swing.JComponent;
@@ -39,37 +37,32 @@ import us.physion.ovation.domain.OvationEntity;
 })
 public class ResourceVisualizationChrome<T extends OvationEntity> extends javax.swing.JPanel {
 
+    private final DataVisualization visualization;
 
     /**
      * Creates new form AbstractResourceVisualizationChrome
      */
-    public ResourceVisualizationChrome(JComponent content, JComponent info) {
+    public ResourceVisualizationChrome(JComponent content, DataVisualization visualization) {
 
+        this.visualization = visualization;
 
         initComponents();
 
         contentPanel.add(content, BorderLayout.CENTER);
         contentPanel.revalidate();
 
-        if (info != null) {
-            infoPanel.add(info, BorderLayout.CENTER);
-        }
-
         infoPanel.setVisible(false);
         infoPanelRoot.revalidate();
 
-        infoButton.addActionListener(new ActionListener() {
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                if (infoButton.isSelected()) {
-                    infoPanel.setVisible(true);
-                } else {
-                    infoPanel.setVisible(false);
-                }
-
-                infoPanelRoot.revalidate();
+        infoButton.addActionListener((ActionEvent e) -> {
+            if (infoButton.isSelected()) {
+                infoPanel.add(visualization.generateInfoPanel(), BorderLayout.CENTER);
+                infoPanel.setVisible(true);
+            } else {
+                infoPanel.setVisible(false);
             }
+
+            infoPanelRoot.revalidate();
         });
 
     }

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/TabularDataVisualizationFactory.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/TabularDataVisualizationFactory.java
@@ -29,8 +29,8 @@ public class TabularDataVisualizationFactory implements VisualizationFactory {
     }
 
     @Override
-    public int getPreferenceForDataContainer(Resource r) {
-        if (mimeTypes.contains(r.getDataContentType()))
+    public int getPreferenceForDataContentType(String contentType) {
+        if (mimeTypes.contains(contentType))
         {
             return 100;
         }

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/VisualizationFactory.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/VisualizationFactory.java
@@ -9,5 +9,5 @@ import us.physion.ovation.domain.Resource;
 public interface VisualizationFactory {
     public DataVisualization createVisualization(Resource r);
 
-    public int getPreferenceForDataContainer(Resource r);
+    public int getPreferenceForDataContentType(String contentType);
 }

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/pdf/PDFVisualizationFactory.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/pdf/PDFVisualizationFactory.java
@@ -213,8 +213,8 @@ public class PDFVisualizationFactory implements VisualizationFactory {
     }
 
     @Override
-    public int getPreferenceForDataContainer(Resource r) {
-        return PDF_MIMETYPE.equals(r.getDataContentType()) ? 100 : -1;
+    public int getPreferenceForDataContentType(String contentType) {
+        return PDF_MIMETYPE.equals(contentType) ? 100 : -1;
     }
 
     public abstract static class LoadingHelper {

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/xls/XLSVisualizationFactory.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/xls/XLSVisualizationFactory.java
@@ -79,8 +79,8 @@ public class XLSVisualizationFactory implements VisualizationFactory {
     }
 
     @Override
-    public int getPreferenceForDataContainer(Resource r) {
-        return XLSX_MIMETYPE.equals(r.getDataContentType()) ? 100 : -1;
+    public int getPreferenceForDataContentType(String contentType) {
+        return XLSX_MIMETYPE.equals(contentType) ? 100 : -1;
     }
 
     private JComponent loadXLSX(File f) {

--- a/ovation-api/pom.xml
+++ b/ovation-api/pom.xml
@@ -27,20 +27,20 @@
         <dependency>
             <groupId>us.physion</groupId>
             <artifactId>ovation-api</artifactId>
-            <version>3.0.3</version>
+            <version>3.0.4-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>us.physion</groupId>
             <artifactId>ovation-test-utils</artifactId>
-            <version>3.0.3</version>
+            <version>3.0.4-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>us.physion</groupId>
             <artifactId>ovation-logging</artifactId>
-            <version>3.0.3</version>
+            <version>3.0.4-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -49,9 +49,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.netflix.rxjava</groupId>
-            <artifactId>rxjava-core</artifactId>
-            <version>0.18.3</version>
+            <groupId>io.reactivex</groupId>
+            <artifactId>rxjava</artifactId>
+            <version>1.0.6</version>
         </dependency>
         
     </dependencies>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -28,7 +28,7 @@
 	<dependency>
             <groupId>us.physion</groupId>
             <artifactId>ovation-test-utils</artifactId>
-            <version>3.0.3</version>
+            <version>3.0.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Several changes to improve performance of Resource browsing:

* Visualization factory plugins must asses preference from content type
alone
* ResponseWrapperFactory caches visualization factory for content type
* VisualizationChrome doesn’t load info pane until it’s
* Updates API to 3.0.4, providing cached content type in Resource
entities (avoiding a round-trip to the DB to get the HEAD Revision)