### PR TITLE
Draft project data drop

### DIFF
--- a/annotation-views/src/main/java/us/physion/ovation/ui/detailviews/ResourceViewTopComponent.java
+++ b/annotation-views/src/main/java/us/physion/ovation/ui/detailviews/ResourceViewTopComponent.java
@@ -48,7 +48,7 @@ import us.physion.ovation.domain.mixin.AttachmentContainer;
 @TopComponent.Description(preferredID = "ResourceViewTopComponent",
         //iconBase="SET/PATH/TO/ICON/HERE",
         persistenceType = TopComponent.PERSISTENCE_ALWAYS)
-@TopComponent.Registration(mode = "properties", openAtStartup = true)
+@TopComponent.Registration(mode = "properties", openAtStartup = false)
 @ActionID(category = "Window", id = "us.physion.ovation.detailviews.ResourceViewTopComponent")
 @ActionReference(path = "Menu/Window" /*
          * , position = 333

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/ProjectVisualizationPanel.form
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/ProjectVisualizationPanel.form
@@ -181,7 +181,7 @@
         <Property name="rows" type="int" value="1"/>
       </Layout>
       <SubComponents>
-        <Component class="us.physion.ovation.ui.editor.FileWell" name="experimentFileWell">
+        <Component class="us.physion.ovation.ui.editor.FileWell" name="dataFileWell">
         </Component>
         <Component class="us.physion.ovation.ui.editor.FileWell" name="analysisFileWell">
         </Component>

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/ProjectVisualizationPanel.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/ProjectVisualizationPanel.java
@@ -24,7 +24,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -39,7 +38,7 @@ import org.openide.util.NbBundle.Messages;
 import us.physion.ovation.domain.AnalysisRecord;
 import us.physion.ovation.domain.Experiment;
 import us.physion.ovation.domain.Folder;
-import us.physion.ovation.domain.Measurement;
+import us.physion.ovation.domain.OvationEntity;
 import us.physion.ovation.domain.Project;
 import us.physion.ovation.domain.Resource;
 import us.physion.ovation.ui.browser.BrowserUtilities;
@@ -59,6 +58,7 @@ import us.physion.ovation.ui.reveal.api.RevealNode;
     "Default_Experiment_Purpose=New Experiment",
     "Project_New_Analysis_Record_Name=New Analysis",
     "Project_Drop_Files_To_Add_Experiment_Data=Drop files to add Experiment data",
+    "Project_Drop_Files=Drop files to upload",
     "Project_Drop_Files_To_Add_Analysis=Drop files to add analyses",
     "Default_Folder_Label=New Folder"
 })
@@ -84,12 +84,8 @@ public class ProjectVisualizationPanel extends AbstractContainerVisualizationPan
 
         startZoneComboBox.setSelectedItem(getProject().getStart().getZone().getID());
 
-        startPicker.addActionListener(new ActionListener() {
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                startDateTimeChanged();
-            }
+        startPicker.addActionListener((ActionEvent e) -> {
+            startDateTimeChanged();
         });
 
         startZoneComboBox.addActionListener((ActionEvent e) -> {
@@ -104,30 +100,35 @@ public class ProjectVisualizationPanel extends AbstractContainerVisualizationPan
             addFolder(true);
         });
 
-        experimentFileWell.setDelegate(new FileWell.AbstractDelegate(Bundle.Project_Drop_Files_To_Add_Experiment_Data()) {
+        dataFileWell.setDelegate(new FileWell.AbstractDelegate(Bundle.Project_Drop_Files()) {
 
             @Override
             public void filesDropped(final File[] files) {
-                ListenableFuture<Experiment> addExp = EventQueueUtilities.runOffEDT(() -> addExperiment(false));
-                Futures.addCallback(addExp, new FutureCallback<Experiment>() {
+                final ProgressHandle ph = ProgressHandleFactory.createHandle(Bundle.Adding_resources());
+
+                final Folder root = (files.length == 1 && files[0].isDirectory()) ?
+                    getProject().addFolder(files[0].getName()) :
+                    addFolder(false);
+                
+                ListenableFuture<OvationEntity> addResources = EventQueueUtilities.runOffEDT(() -> {
+                    return EntityUtilities.insertResources(root,
+                            files,
+                            Lists.newLinkedList(),
+                            Lists.newLinkedList());
+                }, ph);
+
+                Futures.addCallback(addResources, new FutureCallback<OvationEntity>() {
 
                     @Override
-                    public void onSuccess(final Experiment result) {
-                        final ProgressHandle ph = ProgressHandleFactory.createHandle(Bundle.Adding_measurements());
-
-                        EventQueueUtilities.runOffEDT(() -> {
-                            final List<Measurement> m = EntityUtilities.insertMeasurements(result, files);
-                            EventQueueUtilities.runOnEDT(() -> {
-                                if (!m.isEmpty()) {
-                                    RevealNode.forEntity(BrowserUtilities.PROJECT_BROWSER_ID, m.get(0));
-                                }
-                            });
-                        }, ph);
+                    public void onSuccess(final OvationEntity result) {
+                        if (result != null) {
+                            RevealNode.forEntity(BrowserUtilities.PROJECT_BROWSER_ID, result);
+                        }
                     }
 
                     @Override
                     public void onFailure(Throwable t) {
-                        logger.error("Unable to add measurements", t);
+                        logger.error("Unable to display added file(s)", t);
                     }
                 });
             }
@@ -266,7 +267,7 @@ public class ProjectVisualizationPanel extends AbstractContainerVisualizationPan
         projectNameField = new javax.swing.JTextField();
         startZoneComboBox = new javax.swing.JComboBox();
         dropPanelContainer = new javax.swing.JPanel();
-        experimentFileWell = new us.physion.ovation.ui.editor.FileWell();
+        dataFileWell = new us.physion.ovation.ui.editor.FileWell();
         analysisFileWell = new us.physion.ovation.ui.editor.FileWell();
         newFolderHyperlink = new org.jdesktop.swingx.JXHyperlink();
         newExperimentHyperlink = new org.jdesktop.swingx.JXHyperlink();
@@ -305,7 +306,7 @@ public class ProjectVisualizationPanel extends AbstractContainerVisualizationPan
 
         dropPanelContainer.setBackground(java.awt.Color.white);
         dropPanelContainer.setLayout(new java.awt.GridLayout(1, 0));
-        dropPanelContainer.add(experimentFileWell);
+        dropPanelContainer.add(dataFileWell);
         dropPanelContainer.add(analysisFileWell);
 
         org.openide.awt.Mnemonics.setLocalizedText(newFolderHyperlink, org.openide.util.NbBundle.getMessage(ProjectVisualizationPanel.class, "ProjectVisualizationPanel.newFolderHyperlink.text")); // NOI18N
@@ -369,9 +370,9 @@ public class ProjectVisualizationPanel extends AbstractContainerVisualizationPan
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private us.physion.ovation.ui.editor.FileWell analysisFileWell;
+    private us.physion.ovation.ui.editor.FileWell dataFileWell;
     private javax.swing.JLabel dateLabel;
     private javax.swing.JPanel dropPanelContainer;
-    private us.physion.ovation.ui.editor.FileWell experimentFileWell;
     private javax.swing.JScrollPane jScrollPane1;
     private org.jdesktop.swingx.JXHyperlink newExperimentHyperlink;
     private org.jdesktop.swingx.JXHyperlink newFolderHyperlink;

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/ProjectVisualizationPanel.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/ProjectVisualizationPanel.java
@@ -106,13 +106,15 @@ public class ProjectVisualizationPanel extends AbstractContainerVisualizationPan
             public void filesDropped(final File[] files) {
                 final ProgressHandle ph = ProgressHandleFactory.createHandle(Bundle.Adding_resources());
 
-                final Folder root = (files.length == 1 && files[0].isDirectory()) ?
+                boolean rootFolder = (files.length == 1 && files[0].isDirectory());
+                final Folder root = rootFolder ?
                     getProject().addFolder(files[0].getName()) :
                     addFolder(false);
                 
+                
                 ListenableFuture<OvationEntity> addResources = EventQueueUtilities.runOffEDT(() -> {
                     return EntityUtilities.insertResources(root,
-                            files,
+                            rootFolder ? files[0].listFiles() : files,
                             Lists.newLinkedList(),
                             Lists.newLinkedList());
                 }, ph);

--- a/data-viewer/src/main/java/us/physion/ovation/ui/editor/ProjectVisualizationPanel.java
+++ b/data-viewer/src/main/java/us/physion/ovation/ui/editor/ProjectVisualizationPanel.java
@@ -106,12 +106,11 @@ public class ProjectVisualizationPanel extends AbstractContainerVisualizationPan
             public void filesDropped(final File[] files) {
                 final ProgressHandle ph = ProgressHandleFactory.createHandle(Bundle.Adding_resources());
 
-                boolean rootFolder = (files.length == 1 && files[0].isDirectory());
-                final Folder root = rootFolder ?
-                    getProject().addFolder(files[0].getName()) :
-                    addFolder(false);
-                
-                
+                final boolean rootFolder = (files.length == 1 && files[0].isDirectory());
+                final Folder root = rootFolder
+                        ? getProject().addFolder(files[0].getName())
+                        : addFolder(false);
+
                 ListenableFuture<OvationEntity> addResources = EventQueueUtilities.runOffEDT(() -> {
                     return EntityUtilities.insertResources(root,
                             rootFolder ? files[0].listFiles() : files,
@@ -124,7 +123,11 @@ public class ProjectVisualizationPanel extends AbstractContainerVisualizationPan
                     @Override
                     public void onSuccess(final OvationEntity result) {
                         if (result != null) {
-                            RevealNode.forEntity(BrowserUtilities.PROJECT_BROWSER_ID, result);
+                            if (rootFolder) {
+                                RevealNode.forEntity(BrowserUtilities.PROJECT_BROWSER_ID, root);
+                            } else {
+                                RevealNode.forEntity(BrowserUtilities.PROJECT_BROWSER_ID, result);
+                            }
                         }
                     }
 
@@ -192,7 +195,7 @@ public class ProjectVisualizationPanel extends AbstractContainerVisualizationPan
 
         return result;
     }
-    
+
     private AnalysisRecord addAnalysisRecord(final File[] files, final Iterable<Resource> inputs) {
         AnalysisRecord ar = getProject().addAnalysisRecord(Bundle.Project_New_Analysis_Record_Name(),
                 inputs,


### PR DESCRIPTION
- [x] Drop folder
- [x] Drop files
- [x] Display first dropped item

Users can create an Experiment and drop data, but the default data drop
is now files/folders. Creates a default folder root unless user is
dropping a single folder.