### PR TITLE
Registering Windows version and some other install metadata (#213)

### DIFF
--- a/application/installer/ConfigurationLogic.java
+++ b/application/installer/ConfigurationLogic.java
@@ -94,6 +94,20 @@ public class ConfigurationLogic extends ProductConfigurationLogic {
     public boolean allowModifyMode() {
         return false;
     }
+    
+    @Override
+    public Map<String, Object> getAdditionalSystemIntegrationInfo() {
+        Map<String, Object> info = super.getAdditionalSystemIntegrationInfo();
+        if (SystemUtils.isWindows()) {
+            info.put("DisplayVersion", getString("ovation.version"));
+            info.put("Publisher", "Physion LLC");
+            info.put("URLInfoAbout", "https://ovation.io/");
+            info.put("HelpLink", "http://docs.ovation.io/");
+//            info.put("URLUpdateInfo",  "");
+//            info.put("Readme",  readme absolute path);
+        }
+        return info;
+    }
 
     @Override
     public void install(Progress progress) throws InstallationException {

--- a/application/installer/template.xml
+++ b/application/installer/template.xml
@@ -164,6 +164,10 @@
             <replacefilter token="{product-install-directory-name-windows}" value="${suite.props.app.name}"/>
             <replacefilter token="{product-install-directory-name-macosx}"  value="${suite.props.app.name}"/>
         </replace>       
+        <concat destfile="${installer.build.dir}/ext/components/products/helloworld/src/org/mycompany/Bundle.properties" encoding="utf-8" append="true">
+ovation.version=${ovation.version}
+        </concat>
+                 
         <property name="dir.dir" value="${installer.build.dir}/tmpdirfornac"/>
         <mkdir dir="${dir.dir}"/>
 

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -228,6 +228,7 @@
                                 <bin.dir>${basedir}\bin</bin.dir>
                                 <app.ico.file>${basedir}\installer\ovation_48x48.ico</app.ico.file>
                                 <launchers.dir>${project.build.directory}\installer\launchers</launchers.dir>
+                                <ovation.version>${project.version}</ovation.version>
                             </userSettings>
 
                             <licenseName>GNU General Public License, Version 3</licenseName>


### PR DESCRIPTION
I'm still leaving the bundle version to 1.0.0.0.0 because it's unclear to me where that thing is visible.

I do have a patch for that too but it's a bit uglier than this one.